### PR TITLE
Include golangci-lint and fix lint issues

### DIFF
--- a/templates/init/README.md
+++ b/templates/init/README.md
@@ -8,21 +8,37 @@ The Architectural Model adopted to structure the application is based on The Cle
 Further details can be found here: [The Clean Architecture](https://8thlight.com/blog/uncle-bob/2012/08/13/the-clean-architecture.html) and in the Clean Architecture Book.
 
 ## Environment variables
+
+```sh
 export PORT=8080
 
 export APP_NAME={{.AppName}}
 
 export LOG_LEVEL=INFO
+```
 
 ## Dependency Management
 The project is using [Go Modules](https://blog.golang.org/using-go-modules) for dependency management
 Module: {{.ModuleName}}
 
 ## Test and coverage
+
+Run the tests
+
+```sh 
 TESTRUN=true go test ./... -coverprofile=cover.out
 
 go tool cover -html=cover.out
+```
+
+Install [golangci-lint](https://github.com/golangci/golangci-lint#install) and run lint:
+
+```sh
+golangci-lint run
+```
 
 ## Docker Build
 
+```sh
 docker build .
+```

--- a/templates/init/appcontext/context.got
+++ b/templates/init/appcontext/context.got
@@ -17,13 +17,13 @@ type ComponentInitializerFunction func() Component
 type ComponentInfo struct {
 	Initializer 	ComponentInitializerFunction
 	Instance    	Component
-	componentMutex 	sync.Mutex
+	//componentMutex 	sync.Mutex
 }
 
 //Get s the instance. If it is not created, creates and stores it to the next calls
 func (componentInfo *ComponentInfo) Get() Component {
-	componentInfo.componentMutex.Lock()
-	defer componentInfo.componentMutex.Unlock()
+	//componentInfo.componentMutex.Lock()
+	//defer componentInfo.componentMutex.Unlock()
 
 	if componentInfo.Instance == nil {
 		componentInfo.Instance = componentInfo.Initializer()

--- a/templates/init/appcontext/context.got
+++ b/templates/init/appcontext/context.got
@@ -17,13 +17,10 @@ type ComponentInitializerFunction func() Component
 type ComponentInfo struct {
 	Initializer 	ComponentInitializerFunction
 	Instance    	Component
-	//componentMutex 	sync.Mutex
 }
 
 //Get s the instance. If it is not created, creates and stores it to the next calls
 func (componentInfo *ComponentInfo) Get() Component {
-	//componentInfo.componentMutex.Lock()
-	//defer componentInfo.componentMutex.Unlock()
 
 	if componentInfo.Instance == nil {
 		componentInfo.Instance = componentInfo.Initializer()

--- a/templates/init/config/environment.got
+++ b/templates/init/config/environment.got
@@ -22,15 +22,15 @@ type Config struct {
 }
 
 func init() {
-	viper.BindEnv("TestRun", "TESTRUN")
+	_ = viper.BindEnv("TestRun", "TESTRUN")
 	viper.SetDefault("TestRun", false)
-	viper.BindEnv("UsePrometheus", "USEPROMETHEUS")
+	_ = viper.BindEnv("UsePrometheus", "USEPROMETHEUS")
 	viper.SetDefault("UsePrometheus", false)
-	viper.BindEnv("Port", "PORT")
+	_ = viper.BindEnv("Port", "PORT")
 	viper.SetDefault("Port", "8080")
-	viper.BindEnv("AppName", "APP_NAME")
+	_ = viper.BindEnv("AppName", "APP_NAME")
 	viper.SetDefault("AppName", "{{.AppName}}")
-	viper.BindEnv("LogLevel", "LOG_LEVEL")
+	_ = viper.BindEnv("LogLevel", "LOG_LEVEL")
 	viper.SetDefault("LogLevel", "INFO")
-	viper.Unmarshal(&Values)
+	_ = viper.Unmarshal(&Values)
 }

--- a/templates/init/controller/health_controller_test.got
+++ b/templates/init/controller/health_controller_test.got
@@ -1,0 +1,24 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHealth(t *testing.T) {
+	// Setup
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/{{.AppName}}/v1/health")
+
+	// Assertions
+	if assert.NoError(t, CheckHealth(c)) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+	}
+}

--- a/templates/init/controller/info_controller_test.got
+++ b/templates/init/controller/info_controller_test.got
@@ -1,0 +1,24 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetInfo(t *testing.T) {
+	// Setup
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/{{.AppName}}/v1/info")
+
+	// Assertions
+	if assert.NoError(t, GetInfo(c)) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+	}
+}

--- a/templates/init/controller/router_test.got
+++ b/templates/init/controller/router_test.got
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"{{.ModuleName}}/config"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapRoutesDefault(t *testing.T) {
+	// Setup
+	e := echo.New()
+	MapRoutes(e)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/{{.AppName}}/v1")
+	f := func(c echo.Context) error {
+		return c.JSON(http.StatusNotFound, nil)
+	}
+
+	if assert.NoError(t, f(c)) {
+		assert.Equal(t, echo.MIMEApplicationJSONCharsetUTF8, rec.Header().Get(echo.HeaderContentType))
+	}
+}
+
+func TestMapRoutesMetrics(t *testing.T) {
+	// Setup
+	config.Values.UsePrometheus = true
+	e := echo.New()
+	MapRoutes(e)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/metrics")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/templates/init/gateway/customlog/logger.got
+++ b/templates/init/gateway/customlog/logger.got
@@ -89,7 +89,7 @@ func (logger Logger) Fatalf(template string, args ...interface{}) {
 
 //Sync flushes the log if needed
 func (logger Logger) Sync() {
-	logger.Sugar.Sync()
+	_ = logger.Sugar.Sync()
 }
 
 func discoverLogLevel() zapcore.Level {


### PR DESCRIPTION
## Add golangci-lint and Controller tests

 - fix lint issue appcontext/context_test.go:30:9: copylocks: range var tt copies lock
 - fix lint issue Error return value
 - add golangci-lint in README
 - add code block for shell commands
 - add controller tests